### PR TITLE
ONNX & BENTOML API 

### DIFF
--- a/bentoml_api/bentofile.yaml
+++ b/bentoml_api/bentofile.yaml
@@ -1,10 +1,9 @@
-service: src.service:svc
-include:
-  - src/**
-
+service: "src.service:svc"
+labels:
+  owner: mlops-team
+  project: pet-facial-recognition
 python:
   packages:
+    - torch
     - numpy
     - Pillow
-    - onnxruntime
-    - bentoml

--- a/bentoml_api/bentofile.yaml
+++ b/bentoml_api/bentofile.yaml
@@ -1,0 +1,10 @@
+service: src.service:svc
+include:
+  - src/**
+
+python:
+  packages:
+    - numpy
+    - Pillow
+    - onnxruntime
+    - bentoml

--- a/bentoml_api/src/load_model.py
+++ b/bentoml_api/src/load_model.py
@@ -1,0 +1,26 @@
+import onnx
+import bentoml
+
+# Loading ONNX file
+model_path = "models/efficientnet_v2.onnx"
+model_proto = onnx.load(model_path)
+onnx.checker.check_model(model_proto)
+print("Model loaded succesfully!")
+
+# Saving model into BentoML store
+bento_model = bentoml.onnx.save_model(
+    "efficientnet",
+    model_proto,
+    signatures={
+        "run": {
+            "batchable": True,
+        }
+    },
+    metadata={
+        "framework": "onnx",
+        "description": "EfficientNetV2 model for image classification",
+        "version": "1.0",
+    },
+)
+
+print(f"Model saved: {bento_model}")

--- a/bentoml_api/src/load_model.py
+++ b/bentoml_api/src/load_model.py
@@ -1,8 +1,9 @@
-import onnx
 import bentoml
+import onnx
+
 
 # Loading ONNX file
-model_path = "models/efficientnet_v2.onnx"
+model_path = "models/efficientnet.onnx"
 model_proto = onnx.load(model_path)
 onnx.checker.check_model(model_proto)
 print("Model loaded succesfully!")

--- a/bentoml_api/src/service.py
+++ b/bentoml_api/src/service.py
@@ -1,0 +1,38 @@
+import bentoml
+from bentoml.io import Image, JSON
+import numpy as np
+from PIL import Image as PILImage
+
+model_runner = bentoml.models.get("efficientnet:latest").to_runner()
+
+svc = bentoml.Service("efficientnet_service", runners=[model_runner])
+
+
+def preprocess_image(image: PILImage.Image) -> np.ndarray:
+    # Resize image to the model's expected input size
+    input_size = (224, 224)  # Example size; adjust to match your model
+    image = image.resize(input_size).convert("RGB")
+
+    # Convert image to numpy array
+    image_array = np.array(image).astype(np.float32)
+
+    # Normalize pixel values to [0, 1]
+    image_array = image_array / 255.0
+
+    # Add batch dimension (N, C, H, W)
+    image_array = np.expand_dims(image_array.transpose(2, 0, 1), axis=0)
+    return image_array
+
+
+@svc.api(input=Image(), output=JSON())
+def predict(image: PILImage.Image):
+    # Preprocess the input image
+    preprocessed_image = preprocess_image(image)
+
+    # Run inference
+    predictions = model_runner.run.run(preprocessed_image)
+
+    # Get the predicted class (assuming the model outputs probabilities)
+    predicted_class = np.argmax(predictions, axis=1).item()
+
+    return {"predicted_class": predicted_class}

--- a/bentoml_api/src/service.py
+++ b/bentoml_api/src/service.py
@@ -3,6 +3,7 @@ from bentoml.io import Image, JSON
 import numpy as np
 from PIL import Image as PILImage
 from pet_fac_rec.preprocessing import preprocess_image
+from pet_fac_rec.data import label_mapping
 
 model_runner = bentoml.models.get("efficientnet:latest").to_runner()
 
@@ -12,6 +13,13 @@ svc = bentoml.Service("efficientnet_service", runners=[model_runner])
 @svc.api(input=Image(), output=JSON())
 def predict(image: PILImage.Image):
     preprocessed_image = preprocess_image(image)
-    predictions = model_runner.run.run(preprocessed_image)
-    predicted_class = np.argmax(predictions, axis=1).item()
-    return {"predicted_class": predicted_class}
+    logits = model_runner.run.run(preprocessed_image)
+    probabilities = np.exp(logits.squeeze()) / np.sum(np.exp(logits.squeeze()))
+    predicted_class = np.argmax(probabilities).item()
+    probability = probabilities[predicted_class]
+
+    return {
+        "predicted_class": predicted_class,
+        "class_name": list(label_mapping.keys())[list(label_mapping.values()).index(predicted_class)],
+        "probability": probability,
+    }

--- a/bentoml_api/src/service.py
+++ b/bentoml_api/src/service.py
@@ -2,37 +2,16 @@ import bentoml
 from bentoml.io import Image, JSON
 import numpy as np
 from PIL import Image as PILImage
+from pet_fac_rec.preprocessing import preprocess_image
 
 model_runner = bentoml.models.get("efficientnet:latest").to_runner()
 
 svc = bentoml.Service("efficientnet_service", runners=[model_runner])
 
 
-def preprocess_image(image: PILImage.Image) -> np.ndarray:
-    # Resize image to the model's expected input size
-    input_size = (224, 224)  # Example size; adjust to match your model
-    image = image.resize(input_size).convert("RGB")
-
-    # Convert image to numpy array
-    image_array = np.array(image).astype(np.float32)
-
-    # Normalize pixel values to [0, 1]
-    image_array = image_array / 255.0
-
-    # Add batch dimension (N, C, H, W)
-    image_array = np.expand_dims(image_array.transpose(2, 0, 1), axis=0)
-    return image_array
-
-
 @svc.api(input=Image(), output=JSON())
 def predict(image: PILImage.Image):
-    # Preprocess the input image
     preprocessed_image = preprocess_image(image)
-
-    # Run inference
     predictions = model_runner.run.run(preprocessed_image)
-
-    # Get the predicted class (assuming the model outputs probabilities)
     predicted_class = np.argmax(predictions, axis=1).item()
-
     return {"predicted_class": predicted_class}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.7.0
 anyio==4.8.0
+bentoml==1.3.20
 certifi==2024.12.14
 cfgv==3.4.0
 charset-normalizer==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,9 @@ mpmath==1.3.0
 networkx==3.4.2
 nodeenv==1.9.1
 numpy==1.26.4
+onnx==1.17.0
+onnxruntime==1.20.1
+onnxscript==0.1.0.dev20250117
 packaging==24.2
 pandas==2.2.3
 pillow==11.1.0

--- a/src/pet_fac_rec/data.py
+++ b/src/pet_fac_rec/data.py
@@ -10,11 +10,15 @@ from torchvision import transforms
 from PIL import Image
 from datetime import datetime
 from pet_fac_rec.preprocessing import get_transforms
-
+import os
 
 current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+os.makedirs("reports/logs", exist_ok=True)
 logging.basicConfig(filename=f"reports/logs/{current_time}.log", level=logging.INFO)
 log = logging.getLogger(__name__)
+
+# define image classes
+label_mapping = {"happy": 0, "sad": 1, "angry": 2, "other": 3}
 
 
 class MyDataset(Dataset):
@@ -107,7 +111,6 @@ def preprocess(output_folder: Path) -> None:
 
     # Walk through each subdirectory and file to create a data list
     data = []
-    label_mapping = {"happy": 0, "sad": 1, "angry": 2, "other": 3}
 
     for split in ["train", "valid", "test"]:
         split_path = output_folder / split

--- a/src/pet_fac_rec/data.py
+++ b/src/pet_fac_rec/data.py
@@ -9,6 +9,8 @@ from torch.utils.data import Dataset
 from torchvision import transforms
 from PIL import Image
 from datetime import datetime
+from pet_fac_rec.preprocessing import get_transforms
+
 
 current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 logging.basicConfig(filename=f"reports/logs/{current_time}.log", level=logging.INFO)
@@ -32,7 +34,7 @@ class MyDataset(Dataset):
         self.data = self.data[self.data["split"] == split]
         self.labels = self.data["label"].unique()
         self.num_classes = len(self.labels)
-        self.transform = transform
+        self.transform = transform or get_transforms()
 
     def __len__(self) -> int:
         """Return the length of the dataset."""
@@ -130,17 +132,6 @@ def preprocess(output_folder: Path) -> None:
     csv_path = output_folder / "data.csv"
     data_df.to_csv(csv_path, index=False)
     log.info(f"Data saved to CSV at: {csv_path}")
-
-
-def get_default_transforms() -> transforms.Compose:
-    """Return default transformations for the dataset."""
-    return transforms.Compose(
-        [
-            transforms.Resize((224, 224)),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ]
-    )
 
 
 def main():

--- a/src/pet_fac_rec/preprocessing.py
+++ b/src/pet_fac_rec/preprocessing.py
@@ -1,0 +1,19 @@
+from torchvision import transforms
+import numpy as np
+from PIL import Image
+
+
+def get_transforms():
+    return transforms.Compose(
+        [
+            transforms.Resize((224, 224)),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+
+
+def preprocess_image(image: Image.Image) -> np.ndarray:
+    transform = get_transforms()
+    tensor = transform(image)
+    return tensor.unsqueeze(0).numpy()

--- a/src/pet_fac_rec/train.py
+++ b/src/pet_fac_rec/train.py
@@ -13,7 +13,8 @@ import numpy as np
 from pathlib import Path
 from torch.utils.data import DataLoader
 from pet_fac_rec.model import MyEfficientNetModel, MyResNet50Model, MyVGG16Model
-from pet_fac_rec.data import MyDataset, get_default_transforms
+from pet_fac_rec.data import MyDataset
+from pet_fac_rec.preprocessing import get_transforms
 from tqdm import tqdm
 import onnx
 
@@ -82,7 +83,7 @@ def train(
     print(f"Running on dev: {device}")  # Remove later
 
     # Load the dataset
-    transform = get_default_transforms()
+    transform = get_transforms()
     train_dataset = MyDataset(csv_file=Path(hparams.data_csv), split="train", transform=transform)
     valid_dataset = MyDataset(csv_file=Path(hparams.data_csv), split="valid", transform=transform)
     train_dataloader = DataLoader(train_dataset, batch_size=hparams.batch_size, shuffle=True)
@@ -174,7 +175,7 @@ def train(
     try:
         model.eval()
         dummy_input = torch.randn(1, 3, 224, 224).to(device)
-        onnx_save_path = f"models/{model_name}_v2.onnx"
+        onnx_save_path = f"models/{model_name}.onnx"
 
         # Export the model
         torch.onnx.export(


### PR DESCRIPTION
Added .onnx model export and bentoml api. 

Start bentoml session with the following steps (from root directionary):

1. install new dependencies "pip install -e ."
2. create a new .onnx model export that is saved in /models: "invoke trainEffNet"
3. load the new model into bentoml store: "python bentoml_api/src/load_model.py"
4. move into the bentoml dir: "cd bentoml_api"
5. build bentoml: "bentoml build"
6. start bentoml server: "bentoml serve src.service:svc --reload"

now you should be able to access the api via localhost:3000.

@luyentru please review and merge